### PR TITLE
Feature/port development

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,16 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin";
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' http://localhost:3001 ws://localhost:3001;";
 
+    # Proxy configuration for backend API
+    location /api/ {
+        proxy_pass http://homelabarr-backend:3001/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
     # Enable gzip compression
     gzip on;
     gzip_vary on;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { DeploymentMode } from '../types';
 
-const API_BASE_URL = 'http://localhost:3001';  // Use the standard port
+const API_BASE_URL = '/api';  // Use relative path for API requests
 
 async function handleResponse(response: Response) {
   if (!response.ok) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: process.env.BACKEND_URL || 'http://localhost:3001',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
       }


### PR DESCRIPTION
**Summary of Changes**

- **Updated `nginx.conf`**  
  - Added a proxy configuration to forward `/api` requests to the backend service.

- **Modified `src/lib/api.ts`**  
  - Uses a relative `/api` path instead of a hardcoded backend URL.

- **Updated `vite.config.ts`**  
  - Allows configuration of the backend URL through an environment variable.

---

**How It Works**

1. **Development**  
   - Requests are proxied through Vite's dev server.

2. **Production**  
   - Requests are proxied through Nginx.

3. **Relative Paths**  
   - The frontend always uses a relative `/api` path, making it port-agnostic.

---

**Backend Container**

- Still listens internally on **port 3001**.
- The frontend container communicates with the backend via the **internal Docker network** on port 3001.
- Nginx also uses this internal Docker network, so external host port mappings do not affect it.

```yaml
services:
  frontend:
    # ... other frontend config ...
    ports:
      - "8087:80"
    networks:
      - homelabarr

  backend:
    # ... other backend config ...
    environment:
      - NODE_ENV=production
      - PORT=3001  # Keep internal port as 3001
      - CORS_ORIGIN=*
      - DOCKER_SOCKET=/var/run/docker.sock
    ports:
      - "3009:3001"  # Map host port 3009 to container port 3001
    networks:
      - homelabarr
```

**This should solve the issue that was brought up here: [Issue #8](https://github.com/smashingtags/homelabarr/issues/8#issue-2829022464).**

**Thanks to [jbeck22](https://github.com/jbeck22)**
Thank you for pointing out the issue where changing the backend port caused the frontend to fail to connect and show container data.
